### PR TITLE
7 bug when reassigning error variable the nil errors are not nil

### DIFF
--- a/api/api_contracts.go
+++ b/api/api_contracts.go
@@ -28,7 +28,7 @@ func NewCreateContractRequest(startDate time.Time, endDate *time.Time, customerI
 	return &openapi.CreateContractRequest{StartDate: startDate, EndDate: endDate, CustomerId: customerId, PlanId: planId}
 }
 
-func (api *ContractsAPI) ListContracts(limit *float32, cursor *string) (*ListContractsResponse, *client.VayuError) {
+func (api *ContractsAPI) ListContracts(limit *float32, cursor *string) (*ListContractsResponse, error) {
 	if invalidLoggedInStatus := api.vayuClient.ValidateLoggedIn(); invalidLoggedInStatus != nil {
 		return nil, invalidLoggedInStatus
 	}
@@ -55,7 +55,7 @@ func (api *ContractsAPI) ListContracts(limit *float32, cursor *string) (*ListCon
 	return response, nil
 }
 
-func (api *ContractsAPI) GetContract(contractId string) (*GetContractResponse, *client.VayuError) {
+func (api *ContractsAPI) GetContract(contractId string) (*GetContractResponse, error) {
 	if invalidLoggedInStatus := api.vayuClient.ValidateLoggedIn(); invalidLoggedInStatus != nil {
 		return nil, invalidLoggedInStatus
 	}
@@ -73,7 +73,7 @@ func (api *ContractsAPI) GetContract(contractId string) (*GetContractResponse, *
 	return response, nil
 }
 
-func (api *ContractsAPI) CreateContract(input CreateContractRequest) (*CreateContractResponse, *client.VayuError) {
+func (api *ContractsAPI) CreateContract(input CreateContractRequest) (*CreateContractResponse, error) {
 	if invalidLoggedInStatus := api.vayuClient.ValidateLoggedIn(); invalidLoggedInStatus != nil {
 		return nil, invalidLoggedInStatus
 	}
@@ -92,7 +92,7 @@ func (api *ContractsAPI) CreateContract(input CreateContractRequest) (*CreateCon
 	return response, nil
 }
 
-func (api *ContractsAPI) DeleteContract(contractId string) (*DeleteContractResponse, *client.VayuError) {
+func (api *ContractsAPI) DeleteContract(contractId string) (*DeleteContractResponse, error) {
 	if invalidLoggedInStatus := api.vayuClient.ValidateLoggedIn(); invalidLoggedInStatus != nil {
 		return nil, invalidLoggedInStatus
 	}

--- a/api/api_customers.go
+++ b/api/api_customers.go
@@ -34,7 +34,7 @@ func NewUpdateCustomerRequest(name *string, alias *string) *UpdateCustomerReques
 	return &openapi.UpdateCustomerRequest{Name: name, Alias: alias}
 }
 
-func (api *CustomersAPI) ListCustomers(limit *float32, cursor *string) (*ListCustomersResponse, *client.VayuError) {
+func (api *CustomersAPI) ListCustomers(limit *float32, cursor *string) (*ListCustomersResponse, error) {
 	if invalidLoggedInStatus := api.vayuClient.ValidateLoggedIn(); invalidLoggedInStatus != nil {
 		return nil, invalidLoggedInStatus
 	}
@@ -61,7 +61,7 @@ func (api *CustomersAPI) ListCustomers(limit *float32, cursor *string) (*ListCus
 	return response, nil
 }
 
-func (api *CustomersAPI) GetCustomer(customerId string) (*GetCustomerResponse, *client.VayuError) {
+func (api *CustomersAPI) GetCustomer(customerId string) (*GetCustomerResponse, error) {
 	if invalidLoggedInStatus := api.vayuClient.ValidateLoggedIn(); invalidLoggedInStatus != nil {
 		return nil, invalidLoggedInStatus
 	}
@@ -79,7 +79,7 @@ func (api *CustomersAPI) GetCustomer(customerId string) (*GetCustomerResponse, *
 	return response, nil
 }
 
-func (api *CustomersAPI) CreateCustomer(payload CreateCustomerRequest) (*CreateCustomerResponse, *client.VayuError) {
+func (api *CustomersAPI) CreateCustomer(payload CreateCustomerRequest) (*CreateCustomerResponse, error) {
 	if invalidLoggedInStatus := api.vayuClient.ValidateLoggedIn(); invalidLoggedInStatus != nil {
 		return nil, invalidLoggedInStatus
 	}
@@ -98,7 +98,7 @@ func (api *CustomersAPI) CreateCustomer(payload CreateCustomerRequest) (*CreateC
 	return response, nil
 }
 
-func (api *CustomersAPI) UpdateCustomer(customerId string, payload UpdateCustomerRequest) (*UpdateCustomerResponse, *client.VayuError) {
+func (api *CustomersAPI) UpdateCustomer(customerId string, payload UpdateCustomerRequest) (*UpdateCustomerResponse, error) {
 	if invalidLoggedInStatus := api.vayuClient.ValidateLoggedIn(); invalidLoggedInStatus != nil {
 		return nil, invalidLoggedInStatus
 	}
@@ -117,7 +117,7 @@ func (api *CustomersAPI) UpdateCustomer(customerId string, payload UpdateCustome
 	return response, nil
 }
 
-func (api *CustomersAPI) DeleteCustomer(customerId string) (*DeleteCustomerResponse, *client.VayuError) {
+func (api *CustomersAPI) DeleteCustomer(customerId string) (*DeleteCustomerResponse, error) {
 	if invalidLoggedInStatus := api.vayuClient.ValidateLoggedIn(); invalidLoggedInStatus != nil {
 		return nil, invalidLoggedInStatus
 	}

--- a/api/api_events.go
+++ b/api/api_events.go
@@ -43,7 +43,7 @@ func NewQueryEventsRequest(startTime time.Time, endTime time.Time, name string, 
 	}
 }
 
-func (e *EventsAPI) GetEvent(refId string) (*GetEventResponse, *client.VayuError) {
+func (e *EventsAPI) GetEvent(refId string) (*GetEventResponse, error) {
 	if invalidLoggedInStatus := e.vayuClient.ValidateLoggedIn(); invalidLoggedInStatus != nil {
 		return nil, invalidLoggedInStatus
 	}
@@ -61,7 +61,7 @@ func (e *EventsAPI) GetEvent(refId string) (*GetEventResponse, *client.VayuError
 	return response, nil
 }
 
-func (e *EventsAPI) DeleteEvent(refId string) (*DeleteEventResponse, *client.VayuError) {
+func (e *EventsAPI) DeleteEvent(refId string) (*DeleteEventResponse, error) {
 	if invalidLoggedInStatus := e.vayuClient.ValidateLoggedIn(); invalidLoggedInStatus != nil {
 		return nil, invalidLoggedInStatus
 	}
@@ -79,7 +79,7 @@ func (e *EventsAPI) DeleteEvent(refId string) (*DeleteEventResponse, *client.Vay
 	return response, nil
 }
 
-func (e *EventsAPI) QueryEvents(payload QueryEventsRequest) (*QueryEventsResponse, *client.VayuError) {
+func (e *EventsAPI) QueryEvents(payload QueryEventsRequest) (*QueryEventsResponse, error) {
 	if invalidLoggedInStatus := e.vayuClient.ValidateLoggedIn(); invalidLoggedInStatus != nil {
 		return nil, invalidLoggedInStatus
 	}
@@ -109,7 +109,7 @@ func (e *EventsAPI) QueryEvents(payload QueryEventsRequest) (*QueryEventsRespons
 	return response, nil
 }
 
-func (e *EventsAPI) SendEvents(events []Event) (*SendEventsResponse, *client.VayuError) {
+func (e *EventsAPI) SendEvents(events []Event) (*SendEventsResponse, error) {
 	if invalidLoggedInStatus := e.vayuClient.ValidateLoggedIn(); invalidLoggedInStatus != nil {
 		return nil, invalidLoggedInStatus
 	}
@@ -128,7 +128,7 @@ func (e *EventsAPI) SendEvents(events []Event) (*SendEventsResponse, *client.Vay
 	return response, nil
 }
 
-func (e *EventsAPI) SendEventsDryRun(events []Event) (*EventsDryRunResponse, *client.VayuError) {
+func (e *EventsAPI) SendEventsDryRun(events []Event) (*EventsDryRunResponse, error) {
 	if invalidLoggedInStatus := e.vayuClient.ValidateLoggedIn(); invalidLoggedInStatus != nil {
 		return nil, invalidLoggedInStatus
 	}

--- a/api/api_invoices.go
+++ b/api/api_invoices.go
@@ -22,7 +22,7 @@ func NewInvoicesAPI(client *client.VayuClient) *InvoicesAPI {
 	}
 }
 
-func (api *InvoicesAPI) ListInvoices(limit *float32, cursor *string) (*ListInvoicesResponse, *client.VayuError) {
+func (api *InvoicesAPI) ListInvoices(limit *float32, cursor *string) (*ListInvoicesResponse, error) {
 	if invalidLoggedInStatus := api.vayuClient.ValidateLoggedIn(); invalidLoggedInStatus != nil {
 		return nil, invalidLoggedInStatus
 	}
@@ -47,7 +47,7 @@ func (api *InvoicesAPI) ListInvoices(limit *float32, cursor *string) (*ListInvoi
 	return response, nil
 }
 
-func (api *InvoicesAPI) GetInvoice(invoiceId string) (*GetInvoiceResponse, *client.VayuError) {
+func (api *InvoicesAPI) GetInvoice(invoiceId string) (*GetInvoiceResponse, error) {
 	if invalidLoggedInStatus := api.vayuClient.ValidateLoggedIn(); invalidLoggedInStatus != nil {
 		return nil, invalidLoggedInStatus
 	}

--- a/api/api_meters.go
+++ b/api/api_meters.go
@@ -22,7 +22,7 @@ func NewMetersAPI(client *client.VayuClient) *MetersAPI {
 	}
 }
 
-func (api *MetersAPI) ListMeters(limit *float32, cursor *string) (*ListMetersResponse, *client.VayuError) {
+func (api *MetersAPI) ListMeters(limit *float32, cursor *string) (*ListMetersResponse, error) {
 	if invalidLoggedInStatus := api.vayuClient.ValidateLoggedIn(); invalidLoggedInStatus != nil {
 		return nil, invalidLoggedInStatus
 	}
@@ -47,7 +47,7 @@ func (api *MetersAPI) ListMeters(limit *float32, cursor *string) (*ListMetersRes
 	return response, nil
 }
 
-func (api *MetersAPI) GetMeter(meterId string) (*GetMeterResponse, *client.VayuError) {
+func (api *MetersAPI) GetMeter(meterId string) (*GetMeterResponse, error) {
 	if invalidLoggedInStatus := api.vayuClient.ValidateLoggedIn(); invalidLoggedInStatus != nil {
 		return nil, invalidLoggedInStatus
 	}

--- a/api/api_plans.go
+++ b/api/api_plans.go
@@ -23,7 +23,7 @@ func NewPlansAPI(client *client.VayuClient) *PlansAPI {
 	}
 }
 
-func (api *PlansAPI) ListPlans(limit *float32, cursor *string) (*ListPlansResponse, *client.VayuError) {
+func (api *PlansAPI) ListPlans(limit *float32, cursor *string) (*ListPlansResponse, error) {
 	if invalidLoggedInStatus := api.vayuClient.ValidateLoggedIn(); invalidLoggedInStatus != nil {
 		return nil, invalidLoggedInStatus
 	}
@@ -48,7 +48,7 @@ func (api *PlansAPI) ListPlans(limit *float32, cursor *string) (*ListPlansRespon
 	return response, nil
 }
 
-func (api *PlansAPI) GetPlan(planId string) (*GetPlanResponse, *client.VayuError) {
+func (api *PlansAPI) GetPlan(planId string) (*GetPlanResponse, error) {
 	if invalidLoggedInStatus := api.vayuClient.ValidateLoggedIn(); invalidLoggedInStatus != nil {
 		return nil, invalidLoggedInStatus
 	}
@@ -66,7 +66,7 @@ func (api *PlansAPI) GetPlan(planId string) (*GetPlanResponse, *client.VayuError
 	return response, nil
 }
 
-func (api *PlansAPI) DeletePlan(planId string) (*DeletePlanResponse, *client.VayuError) {
+func (api *PlansAPI) DeletePlan(planId string) (*DeletePlanResponse, error) {
 	if invalidLoggedInStatus := api.vayuClient.ValidateLoggedIn(); invalidLoggedInStatus != nil {
 		return nil, invalidLoggedInStatus
 	}

--- a/client/vayu-client.go
+++ b/client/vayu-client.go
@@ -30,7 +30,7 @@ func (ve *VayuError) Error() string {
 	return ve.Title + " - " + ve.Body
 }
 
-func BuildVayuError(err error) *VayuError {
+func BuildVayuError(err error) error {
 	if err == nil {
 		return nil
 	}
@@ -44,7 +44,7 @@ func BuildVayuError(err error) *VayuError {
 	return vayuError
 }
 
-func BuildVayuErrorFromGenericOpenAPIError(err interface{}) *VayuError {
+func BuildVayuErrorFromGenericOpenAPIError(err interface{}) error {
 	genericErr, ok := err.(*openapi.GenericOpenAPIError)
 	if !ok {
 		return BuildVayuError(fmt.Errorf("Unknown error occurred"))
@@ -75,7 +75,7 @@ func NewVayuClient(APIKey string) *VayuClient {
 	return &VayuClient{Client: client, apiKey: APIKey}
 }
 
-func (api *VayuClient) Login() *VayuError {
+func (api *VayuClient) Login() error {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -99,7 +99,7 @@ func (v *VayuClient) IsLoggedIn() bool {
 	return v.accessToken != ""
 }
 
-func (v *VayuClient) ValidateLoggedIn() *VayuError {
+func (v *VayuClient) ValidateLoggedIn() error {
 	if v.IsLoggedIn() {
 		return nil
 	}

--- a/vayu.go
+++ b/vayu.go
@@ -30,7 +30,7 @@ func NewVayu(APIKey string) *Vayu {
 	}
 }
 
-func (v *Vayu) Login() *VayuError {
+func (v *Vayu) Login() error {
 	return v.client.Login()
 }
 


### PR DESCRIPTION
## Title
Fixed reassigning to error of constant type to interface{} error

## Description
When go would reassign a value into a variable of error interface it would not consider it a normal nil instead it would change it to { data = nil }

## Type of Change
**Please indicate if this PR contains:**
- [x] A bug fix
- [ ] A feature request
- [ ] Breaking changes
- [x] An enhancement

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes