### PR TITLE
feat: internalize authentication with Authenticator struct [ENG-4392]

### DIFF
--- a/api/api_events.go
+++ b/api/api_events.go
@@ -43,10 +43,6 @@ func NewQueryEventsRequest(startTime time.Time, endTime time.Time, name string, 
 }
 
 func (e *EventsAPI) GetEvent(refId string) (*GetEventResponse, error) {
-	if invalidLoggedInStatus := e.vayuClient.ValidateLoggedIn(); invalidLoggedInStatus != nil {
-		return nil, invalidLoggedInStatus
-	}
-
 	ctx, cancel := client.GenerateContextWithTimeout()
 	defer cancel()
 
@@ -61,10 +57,6 @@ func (e *EventsAPI) GetEvent(refId string) (*GetEventResponse, error) {
 }
 
 func (e *EventsAPI) DeleteEvent(refId string) (*DeleteEventResponse, error) {
-	if invalidLoggedInStatus := e.vayuClient.ValidateLoggedIn(); invalidLoggedInStatus != nil {
-		return nil, invalidLoggedInStatus
-	}
-
 	ctx, cancel := client.GenerateContextWithTimeout()
 	defer cancel()
 
@@ -79,10 +71,6 @@ func (e *EventsAPI) DeleteEvent(refId string) (*DeleteEventResponse, error) {
 }
 
 func (e *EventsAPI) QueryEvents(payload QueryEventsRequest) (*QueryEventsResponse, error) {
-	if invalidLoggedInStatus := e.vayuClient.ValidateLoggedIn(); invalidLoggedInStatus != nil {
-		return nil, invalidLoggedInStatus
-	}
-
 	ctx, cancel := client.GenerateContextWithTimeout()
 	defer cancel()
 
@@ -109,10 +97,6 @@ func (e *EventsAPI) QueryEvents(payload QueryEventsRequest) (*QueryEventsRespons
 }
 
 func (e *EventsAPI) SendEvents(events []Event) (*SendEventsResponse, error) {
-	if invalidLoggedInStatus := e.vayuClient.ValidateLoggedIn(); invalidLoggedInStatus != nil {
-		return nil, invalidLoggedInStatus
-	}
-
 	ctx, cancel := client.GenerateContextWithTimeout()
 	defer cancel()
 
@@ -128,10 +112,6 @@ func (e *EventsAPI) SendEvents(events []Event) (*SendEventsResponse, error) {
 }
 
 func (e *EventsAPI) SendEventsDryRun(events []Event) (*EventsDryRunResponse, error) {
-	if invalidLoggedInStatus := e.vayuClient.ValidateLoggedIn(); invalidLoggedInStatus != nil {
-		return nil, invalidLoggedInStatus
-	}
-
 	ctx, cancel := client.GenerateContextWithTimeout()
 	defer cancel()
 

--- a/client/authenticator.go
+++ b/client/authenticator.go
@@ -1,0 +1,90 @@
+package client
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/weft-finance/vayu-go/openapi"
+)
+
+const tokenExpiryThreshold = 5 * time.Minute
+
+type Authenticator struct {
+	apiKey      string
+	accessToken string
+	expiresAt   time.Time
+	apiClient   *openapi.APIClient
+}
+
+func NewAuthenticator(apiKey string, apiClient *openapi.APIClient) *Authenticator {
+	return &Authenticator{
+		apiKey:    apiKey,
+		apiClient: apiClient,
+	}
+}
+
+func (a *Authenticator) IsAuthenticated() bool {
+	return a.accessToken != ""
+}
+
+func (a *Authenticator) AccessToken() string {
+	return a.accessToken
+}
+
+func (a *Authenticator) NeedsRefresh() bool {
+	return !a.IsAuthenticated() || time.Now().Add(tokenExpiryThreshold).After(a.expiresAt)
+}
+
+// EnsureValidToken returns a valid access token, logging in or refreshing as needed.
+func (a *Authenticator) EnsureValidToken() (string, error) {
+	if a.NeedsRefresh() {
+		if err := a.Authenticate(); err != nil {
+			return "", err
+		}
+	}
+
+	return a.accessToken, nil
+}
+
+// Authenticate exchanges the refresh token for a new access token.
+func (a *Authenticator) Authenticate() error {
+	ctx, cancel := GenerateContextWithTimeout()
+	defer cancel()
+
+	request := a.apiClient.AuthAPI.Login(ctx)
+	request = request.LoginRequest(openapi.LoginRequest{RefreshToken: a.apiKey})
+	response, _, err := request.Execute()
+
+	if err != nil {
+		return BuildVayuErrorFromGenericOpenAPIError(err)
+	}
+
+	a.accessToken = response.AccessToken
+
+	if err := a.extractJWTExpiry(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (a *Authenticator) extractJWTExpiry() error {
+	token, _, err := new(jwt.Parser).ParseUnverified(a.accessToken, jwt.MapClaims{})
+	if err != nil {
+		return BuildVayuError(fmt.Errorf("failed to parse JWT"))
+	}
+
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		return BuildVayuError(fmt.Errorf("failed to parse JWT claims"))
+	}
+
+	exp, ok := claims["exp"].(float64)
+	if !ok {
+		return BuildVayuError(fmt.Errorf("expiry date not found in JWT"))
+	}
+
+	a.expiresAt = time.Unix(int64(exp), 0)
+	return nil
+}

--- a/client/vayu_client.go
+++ b/client/vayu_client.go
@@ -1,30 +1,36 @@
 package client
 
 import (
-	"fmt"
-	"time"
+	"net/http"
 
 	"github.com/weft-finance/vayu-go/openapi"
 )
 
 type VayuClient struct {
-	accessToken string
-	expiresAt   time.Time
-	apiKey      string
-	Client      *openapi.APIClient
+	auth   *Authenticator
+	Client *openapi.APIClient
 }
 
 func NewVayuClient(APIKey string) *VayuClient {
-	client := openapi.NewAPIClient(openapi.NewConfiguration())
+	apiClient := openapi.NewAPIClient(openapi.NewConfiguration())
 
-	cfg := client.GetConfig()
+	cfg := apiClient.GetConfig()
 	cfg.UserAgent = "VayuSDK/go"
 
-	return &VayuClient{Client: client, apiKey: APIKey}
+	auth := NewAuthenticator(APIKey, apiClient)
+
+	vc := &VayuClient{
+		auth:   auth,
+		Client: apiClient,
+	}
+
+	vc.installRoundTripper()
+
+	return vc
 }
 
-func (api *VayuClient) SetCustomHost(host string) {
-	cfg := api.Client.GetConfig()
+func (vc *VayuClient) SetCustomHost(host string) {
+	cfg := vc.Client.GetConfig()
 	cfg.Servers = openapi.ServerConfigurations{
 		{
 			URL:         host,
@@ -33,38 +39,29 @@ func (api *VayuClient) SetCustomHost(host string) {
 	}
 }
 
-func (api *VayuClient) Login() error {
-	ctx, cancel := GenerateContextWithTimeout()
-	defer cancel()
+// Deprecated: Authentication is now handled automatically. You can remove this call.
+func (vc *VayuClient) Login() error {
+	return vc.auth.Authenticate()
+}
 
-	request := api.Client.AuthAPI.Login(ctx)
-	request = request.LoginRequest(openapi.LoginRequest{RefreshToken: api.apiKey})
-	oApiResponse, _, err := request.Execute()
+func (vc *VayuClient) IsLoggedIn() bool {
+	return vc.auth.IsAuthenticated()
+}
 
-	if err != nil {
-		return BuildVayuErrorFromGenericOpenAPIError(err)
-	}
-
-	api.accessToken = oApiResponse.AccessToken
-
-	err = api.extractJWTExpiryDate()
-	if err != nil {
-		return BuildVayuError(err)
-	}
-
-	api.buildClientConfig()
-
+// Deprecated: Authentication is now handled automatically.
+func (vc *VayuClient) ValidateLoggedIn() error {
 	return nil
 }
 
-func (api *VayuClient) IsLoggedIn() bool {
-	return api.accessToken != ""
-}
+func (vc *VayuClient) installRoundTripper() {
+	cfg := vc.Client.GetConfig()
 
-func (api *VayuClient) ValidateLoggedIn() error {
-	if api.IsLoggedIn() {
-		return nil
+	if cfg.HTTPClient.Transport == nil {
+		cfg.HTTPClient.Transport = http.DefaultTransport
 	}
 
-	return BuildVayuError(fmt.Errorf("vayu client is not logged in. please login before calling this method"))
+	cfg.HTTPClient.Transport = &vayuRoundTripper{
+		rt:   cfg.HTTPClient.Transport,
+		auth: vc.auth,
+	}
 }

--- a/client/vayu_roundtripper.go
+++ b/client/vayu_roundtripper.go
@@ -1,68 +1,53 @@
 package client
 
 import (
-	"fmt"
 	"net/http"
-	"time"
-
-	"github.com/golang-jwt/jwt/v5"
 )
 
-func (api *VayuClient) extractJWTExpiryDate() error {
-	token, _, err := new(jwt.Parser).ParseUnverified(api.accessToken, jwt.MapClaims{})
-	if err != nil {
-		return BuildVayuError(fmt.Errorf("failed to parse JWT"))
-	}
-
-	if claims, ok := token.Claims.(jwt.MapClaims); ok {
-		if exp, ok := claims["exp"].(float64); ok {
-			api.expiresAt = time.Unix(int64(exp), 0)
-		} else {
-			return BuildVayuError(fmt.Errorf("expiry date not found in JWT"))
-		}
-	}
-
-	return nil
-}
-
-func (api *VayuClient) buildClientConfig() {
-	cfg := api.Client.GetConfig()
-	cfg.AddDefaultHeader("Authorization", "Bearer "+api.accessToken)
-
-	if cfg.HTTPClient.Transport == nil {
-		cfg.HTTPClient.Transport = http.DefaultTransport
-	}
-
-	cfg.HTTPClient.Transport = &vayuRoundTripper{
-		rt:  cfg.HTTPClient.Transport,
-		api: api,
-	}
-}
-
 type vayuRoundTripper struct {
-	rt  http.RoundTripper
-	api *VayuClient
+	rt   http.RoundTripper
+	auth *Authenticator
 }
-
-const TokenExpiryThreshold = 5 * time.Minute
 
 func (c *vayuRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Skip auth for login endpoint (prevents recursion)
 	if req.URL.Path == "/login" {
 		return c.rt.RoundTrip(req)
 	}
 
-	if err := c.api.ValidateLoggedIn(); err != nil {
+	// Get a valid token (lazy login + proactive refresh)
+	token, err := c.auth.EnsureValidToken()
+	if err != nil {
 		return nil, err
 	}
 
-	if time.Now().Add(TokenExpiryThreshold).After(c.api.expiresAt) {
-		err := c.api.Login()
-		if err != nil {
-			return nil, err
-		}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := c.rt.RoundTrip(req)
+	if err != nil {
+		return nil, err
 	}
 
-	req.Header.Set("Authorization", "Bearer "+c.api.accessToken)
+	// 401 retry: re-authenticate and retry once
+	if resp.StatusCode == 401 {
+		resp.Body.Close()
 
-	return c.rt.RoundTrip(req)
+		if err := c.auth.Authenticate(); err != nil {
+			return nil, err
+		}
+
+		// Restore request body for POST/PUT/PATCH retry
+		if req.GetBody != nil {
+			newBody, err := req.GetBody()
+			if err != nil {
+				return nil, err
+			}
+			req.Body = newBody
+		}
+
+		req.Header.Set("Authorization", "Bearer "+c.auth.AccessToken())
+		return c.rt.RoundTrip(req)
+	}
+
+	return resp, nil
 }

--- a/vayu.go
+++ b/vayu.go
@@ -1,8 +1,6 @@
 package VayuSDK
 
 import (
-	"fmt"
-
 	"github.com/weft-finance/vayu-go/api"
 	"github.com/weft-finance/vayu-go/client"
 )
@@ -36,18 +34,13 @@ func (v *Vayu) SetCustomHost(host string) {
 	v.client.SetCustomHost(host)
 }
 
+// Deprecated: Authentication is now handled automatically. You can remove this call.
 func (v *Vayu) Login() error {
 	return v.client.Login()
 }
 
 func (v *Vayu) IsLoggedIn() bool {
-	loggedIn := v.client.IsLoggedIn()
-
-	if !loggedIn {
-		fmt.Println("vayu client is not logged in. please call `vayu.login()` before calling this method'")
-	}
-
-	return loggedIn
+	return v.client.IsLoggedIn()
 }
 
 // Types


### PR DESCRIPTION
## Summary
- **New `Authenticator` struct** (`client/authenticator.go`) — owns the full token lifecycle: lazy login, token storage, JWT expiry tracking, and proactive refresh
- **Rewrote `VayuClient`** as a thin shell delegating all auth to `Authenticator`; RoundTripper installs once (fixes double-wrapping bug)
- **Rewrote `RoundTripper`** with lazy auth via `EnsureValidToken()` and 401 retry with request body restoration
- **Deprecated `Login()`** — SDK now authenticates lazily on first API call; explicit login still works for backward compat
- **Removed `ValidateLoggedIn` guards** from all 5 `EventsAPI` methods and cleaned up `fmt.Println` from `IsLoggedIn()`

## Bugs Fixed
- Transport double-wrapping on every `Login()` call
- No lazy login (required explicit `.Login()` before any API call)
- No 401 retry (expired tokens caused immediate request failures)

## Test Plan
- [x] `go build ./...` passes (exit 0)
- [x] `go vet ./...` passes (exit 0)
- [ ] Manual smoke test: instantiate `Vayu`, call an API method without calling `Login()` first — should authenticate lazily
- [ ] Manual smoke test: verify 401 retry by letting token expire and making a request

🤖 Generated with [Claude Code](https://claude.com/claude-code)