### PR TITLE
feat: add Credits, Integrations, Reports wrappers + fixes [ENG-4438]

### DIFF
--- a/api/api_credits.go
+++ b/api/api_credits.go
@@ -1,0 +1,75 @@
+// api/api_credits.go
+package api
+
+import (
+	"github.com/weft-finance/vayu-go/client"
+	"github.com/weft-finance/vayu-go/openapi"
+)
+
+type CreditsAPI struct {
+	vayuClient *client.VayuClient
+}
+
+type DeductCreditsRequest = openapi.DeductCreditsRequest
+type GrantCreditsRequest = openapi.GrantCreditsRequest
+type ListCreditLedgerEntriesResponse = openapi.ListCreditLedgerEntriesResponse
+
+func NewCreditsAPI(client *client.VayuClient) *CreditsAPI {
+	return &CreditsAPI{
+		vayuClient: client,
+	}
+}
+
+func (api *CreditsAPI) DeductCredits(input DeductCreditsRequest) error {
+	ctx, cancel := client.GenerateContextWithTimeout()
+	defer cancel()
+
+	request := api.vayuClient.Client.CreditsAPI.DeductCredits(ctx)
+	request = request.DeductCreditsRequest((openapi.DeductCreditsRequest)(input))
+	_, err := request.Execute()
+
+	if err != nil {
+		return client.BuildVayuErrorFromGenericOpenAPIError(err)
+	}
+
+	return nil
+}
+
+func (api *CreditsAPI) GrantCredits(input GrantCreditsRequest) error {
+	ctx, cancel := client.GenerateContextWithTimeout()
+	defer cancel()
+
+	request := api.vayuClient.Client.CreditsAPI.GrantCredits(ctx)
+	request = request.GrantCreditsRequest((openapi.GrantCreditsRequest)(input))
+	_, err := request.Execute()
+
+	if err != nil {
+		return client.BuildVayuErrorFromGenericOpenAPIError(err)
+	}
+
+	return nil
+}
+
+func (api *CreditsAPI) ListCreditLedgerEntries(customerId string, limit *float32, cursor *string) (*ListCreditLedgerEntriesResponse, error) {
+	ctx, cancel := client.GenerateContextWithTimeout()
+	defer cancel()
+
+	request := api.vayuClient.Client.CreditsAPI.ListCreditLedgerEntries(ctx)
+	request = request.CustomerId(customerId)
+
+	if limit != nil {
+		request = request.Limit(*limit)
+	}
+
+	if cursor != nil {
+		request = request.Cursor(*cursor)
+	}
+
+	response, _, err := request.Execute()
+
+	if err != nil {
+		return nil, client.BuildVayuErrorFromGenericOpenAPIError(err)
+	}
+
+	return response, nil
+}

--- a/api/api_integrations.go
+++ b/api/api_integrations.go
@@ -1,0 +1,51 @@
+// api/api_integrations.go
+package api
+
+import (
+	"github.com/weft-finance/vayu-go/client"
+	"github.com/weft-finance/vayu-go/openapi"
+)
+
+type IntegrationsAPI struct {
+	vayuClient *client.VayuClient
+}
+
+type NetSuiteExportSalesOrderRequest = openapi.NetSuiteExportSalesOrderRequest
+type NetSuiteSyncInvoicesResponse = openapi.NetSuiteSyncInvoicesResponse
+type NetSuiteSyncInvoicesRequest = openapi.NetSuiteSyncInvoicesRequest
+
+func NewIntegrationsAPI(client *client.VayuClient) *IntegrationsAPI {
+	return &IntegrationsAPI{
+		vayuClient: client,
+	}
+}
+
+func (api *IntegrationsAPI) ExportNetSuiteSalesOrder(input NetSuiteExportSalesOrderRequest) error {
+	ctx, cancel := client.GenerateContextWithTimeout()
+	defer cancel()
+
+	request := api.vayuClient.Client.IntegrationsAPI.ExportNetSuiteSalesOrder(ctx)
+	request = request.NetSuiteExportSalesOrderRequest((openapi.NetSuiteExportSalesOrderRequest)(input))
+	_, err := request.Execute()
+
+	if err != nil {
+		return client.BuildVayuErrorFromGenericOpenAPIError(err)
+	}
+
+	return nil
+}
+
+func (api *IntegrationsAPI) NetSuiteSyncInvoices(input NetSuiteSyncInvoicesRequest) (*NetSuiteSyncInvoicesResponse, error) {
+	ctx, cancel := client.GenerateContextWithTimeout()
+	defer cancel()
+
+	request := api.vayuClient.Client.IntegrationsAPI.NetSuiteSyncInvoices(ctx)
+	request = request.NetSuiteSyncInvoicesRequest((openapi.NetSuiteSyncInvoicesRequest)(input))
+	response, _, err := request.Execute()
+
+	if err != nil {
+		return nil, client.BuildVayuErrorFromGenericOpenAPIError(err)
+	}
+
+	return response, nil
+}

--- a/api/api_meters.go
+++ b/api/api_meters.go
@@ -12,6 +12,9 @@ type MetersAPI struct {
 type Meter = openapi.Meter
 type ListMetersResponse = openapi.ListMetersResponse
 type GetMeterResponse = openapi.GetMeterResponse
+type UpdateMeterRequest = openapi.UpdateMeterRequest
+type UpdateMeterResponse = openapi.UpdateMeterResponse
+type DeleteMeterResponse = openapi.DeleteMeterResponse
 
 func NewMetersAPI(client *client.VayuClient) *MetersAPI {
 	return &MetersAPI{
@@ -45,6 +48,35 @@ func (api *MetersAPI) GetMeter(meterId string) (*GetMeterResponse, error) {
 	defer cancel()
 
 	request := api.vayuClient.Client.MetersAPI.GetMeter(ctx, meterId)
+	response, _, err := request.Execute()
+
+	if err != nil {
+		return nil, client.BuildVayuErrorFromGenericOpenAPIError(err)
+	}
+
+	return response, nil
+}
+
+func (api *MetersAPI) UpdateMeter(meterId string, input UpdateMeterRequest) (*UpdateMeterResponse, error) {
+	ctx, cancel := client.GenerateContextWithTimeout()
+	defer cancel()
+
+	request := api.vayuClient.Client.MetersAPI.UpdateMeter(ctx, meterId)
+	request = request.UpdateMeterRequest((openapi.UpdateMeterRequest)(input))
+	response, _, err := request.Execute()
+
+	if err != nil {
+		return nil, client.BuildVayuErrorFromGenericOpenAPIError(err)
+	}
+
+	return response, nil
+}
+
+func (api *MetersAPI) DeleteMeter(meterId string) (*DeleteMeterResponse, error) {
+	ctx, cancel := client.GenerateContextWithTimeout()
+	defer cancel()
+
+	request := api.vayuClient.Client.MetersAPI.DeleteMeter(ctx, meterId)
 	response, _, err := request.Execute()
 
 	if err != nil {

--- a/api/api_reports.go
+++ b/api/api_reports.go
@@ -1,0 +1,62 @@
+// api/api_reports.go
+package api
+
+import (
+	"github.com/weft-finance/vayu-go/client"
+	"github.com/weft-finance/vayu-go/openapi"
+)
+
+type ReportsAPI struct {
+	vayuClient *client.VayuClient
+}
+
+type GetCommitmentReportResponse = openapi.GetCommitmentReportResponse
+type GetProductsUsageReportResponse = openapi.GetProductsUsageReportResponse
+
+func NewReportsAPI(client *client.VayuClient) *ReportsAPI {
+	return &ReportsAPI{
+		vayuClient: client,
+	}
+}
+
+func (api *ReportsAPI) GetCommitmentReport(reportId *string) (*GetCommitmentReportResponse, error) {
+	ctx, cancel := client.GenerateContextWithTimeout()
+	defer cancel()
+
+	request := api.vayuClient.Client.ReportsAPI.GetCommitmentReportResponse(ctx)
+
+	if reportId != nil {
+		request = request.ReportId(*reportId)
+	}
+
+	response, _, err := request.Execute()
+
+	if err != nil {
+		return nil, client.BuildVayuErrorFromGenericOpenAPIError(err)
+	}
+
+	return response, nil
+}
+
+func (api *ReportsAPI) GetProductsUsageReport(limit *float32, cursor *string) (*GetProductsUsageReportResponse, error) {
+	ctx, cancel := client.GenerateContextWithTimeout()
+	defer cancel()
+
+	request := api.vayuClient.Client.ReportsAPI.GetProductsUsageReport(ctx)
+
+	if limit != nil {
+		request = request.Limit(*limit)
+	}
+
+	if cursor != nil {
+		request = request.Cursor(*cursor)
+	}
+
+	response, _, err := request.Execute()
+
+	if err != nil {
+		return nil, client.BuildVayuErrorFromGenericOpenAPIError(err)
+	}
+
+	return response, nil
+}

--- a/api/api_webhooks.go
+++ b/api/api_webhooks.go
@@ -26,7 +26,7 @@ func NewWebhookSubscribeRequest(callbackUrl string, eventType NotificationEventT
 	}
 }
 
-func (api *PlansAPI) Subscribe(payload WebhookSubscribeRequest) error {
+func (api *WebhooksAPI) Subscribe(payload WebhookSubscribeRequest) error {
 	ctx, cancel := client.GenerateContextWithTimeout()
 	defer cancel()
 

--- a/vayu.go
+++ b/vayu.go
@@ -12,8 +12,11 @@ type Vayu struct {
 	Events    *api.EventsAPI
 	Invoices  *api.InvoicesAPI
 	Meters    *api.MetersAPI
-	Plans     *api.PlansAPI
-	Webhooks  *api.WebhooksAPI
+	Plans        *api.PlansAPI
+	Webhooks     *api.WebhooksAPI
+	Credits      *api.CreditsAPI
+	Integrations *api.IntegrationsAPI
+	Reports      *api.ReportsAPI
 }
 
 func NewVayu(APIKey string) *Vayu {
@@ -26,7 +29,10 @@ func NewVayu(APIKey string) *Vayu {
 		Invoices:  api.NewInvoicesAPI(vayuClient),
 		Meters:    api.NewMetersAPI(vayuClient),
 		Plans:     api.NewPlansAPI(vayuClient),
-		Webhooks:  api.NewWebhooksAPI(vayuClient),
+		Webhooks:     api.NewWebhooksAPI(vayuClient),
+		Credits:      api.NewCreditsAPI(vayuClient),
+		Integrations: api.NewIntegrationsAPI(vayuClient),
+		Reports:      api.NewReportsAPI(vayuClient),
 	}
 }
 
@@ -97,4 +103,27 @@ type (
 	ListPlansResponse  = api.ListPlansResponse
 	GetPlanResponse    = api.GetPlanResponse
 	DeletePlanResponse = api.DeletePlanResponse
+)
+
+type (
+	DeductCreditsRequest            = api.DeductCreditsRequest
+	GrantCreditsRequest             = api.GrantCreditsRequest
+	ListCreditLedgerEntriesResponse = api.ListCreditLedgerEntriesResponse
+)
+
+type (
+	UpdateMeterRequest  = api.UpdateMeterRequest
+	UpdateMeterResponse = api.UpdateMeterResponse
+	DeleteMeterResponse = api.DeleteMeterResponse
+)
+
+type (
+	NetSuiteExportSalesOrderRequest = api.NetSuiteExportSalesOrderRequest
+	NetSuiteSyncInvoicesRequest     = api.NetSuiteSyncInvoicesRequest
+	NetSuiteSyncInvoicesResponse    = api.NetSuiteSyncInvoicesResponse
+)
+
+type (
+	GetCommitmentReportResponse    = api.GetCommitmentReportResponse
+	GetProductsUsageReportResponse = api.GetProductsUsageReportResponse
 )


### PR DESCRIPTION
## Summary
- Add `CreditsAPI` with `DeductCredits`, `GrantCredits`, `ListCreditLedgerEntries`
- Add `IntegrationsAPI` with `ExportNetSuiteSalesOrder`, `NetSuiteSyncInvoices`
- Add `ReportsAPI` with `GetCommitmentReport`, `GetProductsUsageReport`
- Fix `MetersAPI`: add missing `UpdateMeter`, `DeleteMeter` methods
- Fix `WebhooksAPI`: `Subscribe` was on wrong receiver (`PlansAPI` → `WebhooksAPI`)

## Test plan
- [ ] `go build ./...` passes
- [ ] Manual test: credits, integrations, reports endpoints work
- [ ] Verify `Webhooks.Subscribe()` works (was broken due to wrong receiver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)